### PR TITLE
Attempt to catch a couple of edge conditions that might be causing hangs

### DIFF
--- a/watch/polling.go
+++ b/watch/polling.go
@@ -84,6 +84,12 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, origFi os.FileInfo) *Fi
 				prevSize = fw.Size
 				continue
 			}
+			// File got bigger?
+			if prevSize > 0 && prevSize < fw.Size {
+				changes.NotifyModified()
+				prevSize = fw.Size
+				continue
+			}
 			prevSize = fw.Size
 
 			// File was appended to (changed)?


### PR DESCRIPTION
Pulled in from upstream.

If busy logfiles are rotated, sometimes LMC hangs, i suspect somewhere inside the Tail.  Proving quite tricky to repro, and to narrow down - spotted a couple of likely looking fixes upstream that might help (we primarily using "polling" mode, but the fix on inotify looked interesting too).

/cc @mathpl 